### PR TITLE
Improve shop cocktails UI

### DIFF
--- a/src/app/shop/[id]/page.tsx
+++ b/src/app/shop/[id]/page.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import AddToCartButton from "@/components/cart/AddToCartButton";
 import { supabase } from "@/lib/supabaseClient";
+import { cocktailFlavorMap, FlavorProfile } from "@/data/cocktailInfo";
 
 interface CocktailSize {
   id: string;
@@ -16,7 +17,7 @@ export default async function CocktailDetailPage({
 }) {
   const { data: cocktail, error } = await supabase
     .from("cocktails")
-    .select(`id, name, description, image_url`)
+    .select(`id, name, description, image_url, alcohol_percentage`)
     .eq("id", params.id)
     .single();
 
@@ -33,6 +34,8 @@ export default async function CocktailDetailPage({
     .select("id, label, volume_ml, price, available")
     .eq("cocktail_id", params.id)
     .eq("available", true);
+
+  const flavor: FlavorProfile | undefined = cocktailFlavorMap[cocktail.id];
 
   return (
     <section className="py-24 px-6">
@@ -52,6 +55,37 @@ export default async function CocktailDetailPage({
           </h1>
           {cocktail.description && (
             <p className="text-cosmic-silver">{cocktail.description}</p>
+          )}
+
+          {/* Alcohol strength bar */}
+          <div>
+            <p className="text-sm text-cosmic-silver mb-1">Alcohol strength</p>
+            <div className="w-full bg-cosmic-sky/40 h-3 rounded">
+              <div
+                className="h-3 bg-cosmic-gold rounded"
+                style={{ width: `${cocktail.alcohol_percentage}%` }}
+              />
+            </div>
+          </div>
+
+          {/* Flavor profile */}
+          {flavor && (
+            <div className="space-y-2">
+              <p className="text-sm text-cosmic-silver">Flavor profile</p>
+              {Object.entries(flavor).map(([key, value]) => (
+                <div key={key} className="flex items-center gap-2">
+                  <span className="w-20 capitalize text-sm text-cosmic-fog">
+                    {key}
+                  </span>
+                  <div className="flex-1 bg-cosmic-sky/40 h-2 rounded">
+                    <div
+                      className="h-2 bg-cosmic-gold rounded"
+                      style={{ width: `${value}%` }}
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
           )}
 
           {sizes && sizes.length > 0 && (

--- a/src/app/shop/components/CocktailRow.tsx
+++ b/src/app/shop/components/CocktailRow.tsx
@@ -3,6 +3,7 @@
 import { CocktailWithPrice } from "@/types";
 import Link from "next/link";
 import Image from "next/image";
+import AddToCartButton from "@/components/cart/AddToCartButton";
 
 type CocktailRowProps = {
   title: string;
@@ -21,28 +22,41 @@ export default function CocktailRow({ title, cocktails }: CocktailRowProps) {
 
         <div className="flex overflow-x-auto gap-6 pb-2">
           {cocktails.map((cocktail) => (
-            <Link
+            <div
               key={cocktail.id}
-              href={`/shop/${cocktail.id}`} // luego usaremos el slug
               className="min-w-[220px] flex-shrink-0 rounded-lg bg-white/5 backdrop-blur-sm p-4 border border-cosmic-gold/10 hover:border-cosmic-gold/30 hover:scale-105 transition-transform duration-300"
             >
-              <div className="relative w-full h-48 rounded-lg overflow-hidden mb-4">
-                <Image
-                  src={cocktail.image_url ?? "/images/default-cocktail.webp"}
-                  alt={cocktail.name}
-                  fill
-                  className="object-cover"
+              <Link href={`/shop/${cocktail.id}`}> 
+                <div className="relative w-full h-48 rounded-lg overflow-hidden mb-4">
+                  <Image
+                    src={cocktail.image_url ?? "/images/default-cocktail.webp"}
+                    alt={cocktail.name}
+                    fill
+                    className="object-cover"
+                  />
+                </div>
+                <h3 className="text-cosmic-gold text-lg font-[--font-unica] mb-1">
+                  {cocktail.name}
+                </h3>
+                <p className="text-cosmic-silver text-sm italic">
+                  {cocktail.min_price
+                    ? `From €${cocktail.min_price}`
+                    : "Coming soon"}
+                </p>
+              </Link>
+              {cocktail.min_price !== null && cocktail.min_size_id && (
+                <AddToCartButton
+                  product={{
+                    id: cocktail.min_size_id,
+                    name: cocktail.name,
+                    slug: cocktail.id,
+                    image: cocktail.image_url ?? "/images/default-cocktail.webp",
+                    description: cocktail.description ?? "",
+                    price: cocktail.min_price,
+                  }}
                 />
-              </div>
-              <h3 className="text-cosmic-gold text-lg font-[--font-unica] mb-1">
-                {cocktail.name}
-              </h3>
-              <p className="text-cosmic-silver text-sm italic">
-                {cocktail.min_price
-                  ? `From €${cocktail.min_price}`
-                  : "Coming soon"}
-              </p>
-            </Link>
+              )}
+            </div>
           ))}
         </div>
       </div>

--- a/src/app/shop/page.tsx
+++ b/src/app/shop/page.tsx
@@ -40,7 +40,7 @@ export default function ShopPage() {
         cocktails.map(async (cocktail) => {
           const { data: sizes, error: sizeError } = await supabase
             .from("cocktail_sizes")
-            .select("price")
+            .select("id, price")
             .eq("cocktail_id", cocktail.id)
             .eq("available", true);
 
@@ -50,6 +50,12 @@ export default function ShopPage() {
             sizes && sizes.length > 0
               ? Math.min(...sizes.map((s) => s.price))
               : null;
+          const minSizeId =
+            sizes && sizes.length > 0
+              ? sizes.reduce((prev, curr) =>
+                  curr.price < prev.price ? curr : prev
+                ).id
+              : null;
 
           return {
             id: cocktail.id,
@@ -57,6 +63,7 @@ export default function ShopPage() {
             description: cocktail.description,
             image_url: cocktail.image_url,
             min_price: minPrice,
+            min_size_id: minSizeId,
             alcohol_percentage: cocktail.alcohol_percentage,
             has_non_alcoholic_version: cocktail.has_non_alcoholic_version,
           };

--- a/src/data/cocktailInfo.ts
+++ b/src/data/cocktailInfo.ts
@@ -1,0 +1,13 @@
+export type FlavorProfile = {
+  bitter: number;
+  sweet: number;
+  tropical: number;
+  sour: number;
+};
+
+export const cocktailFlavorMap: Record<string, FlavorProfile> = {
+  // Example static data; in real scenario this might come from the database
+  "1": { bitter: 60, sweet: 30, tropical: 10, sour: 20 },
+  "2": { bitter: 20, sweet: 70, tropical: 40, sour: 30 },
+  "3": { bitter: 10, sweet: 40, tropical: 80, sour: 20 },
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,6 +15,7 @@ export type CocktailWithPrice = {
   description: string | null;
   image_url: string | null;
   min_price: number | null;
+  min_size_id: string | null;
   alcohol_percentage: number;
   has_non_alcoholic_version: boolean;
 };


### PR DESCRIPTION
## Summary
- extend cocktail data with cheapest size id
- allow adding cocktails to cart from shop listing
- show alcohol strength and flavor bars on detail pages
- add placeholder flavor profiles

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68515db5749c832facff23af540b6c4e