### PR TITLE
Fix size queries for add to cart

### DIFF
--- a/src/app/shop/[id]/page.tsx
+++ b/src/app/shop/[id]/page.tsx
@@ -5,9 +5,11 @@ import { cocktailFlavorMap, FlavorProfile } from "@/data/cocktailInfo";
 
 interface CocktailSize {
   id: string;
-  label: string | null;
-  volume_ml: number | null;
   price: number;
+  sizes: {
+    name: string | null;
+    volume_ml: number | null;
+  } | null;
 }
 
 export default async function CocktailDetailPage({
@@ -33,7 +35,7 @@ export default async function CocktailDetailPage({
 
   const { data: sizes } = await supabase
     .from("cocktail_sizes")
-    .select("id, label, volume_ml, price, available")
+    .select(`id, price, available, sizes ( name, volume_ml )`)
     .eq("cocktail_id", params.id)
     .eq("available", true);
 
@@ -110,7 +112,7 @@ export default async function CocktailDetailPage({
                 >
                   <div>
                     <p className="font-[--font-josefin]">
-                      {size.label ?? `${size.volume_ml}ml`}
+                      {size.sizes?.name ?? `${size.sizes?.volume_ml ?? 0}ml`}
                     </p>
                     <p className="text-sm text-cosmic-fog">
                       €{size.price.toFixed(2)}
@@ -120,7 +122,7 @@ export default async function CocktailDetailPage({
                     product={{
                       id: size.id,
                       name: `${cocktail.name} (${
-                        size.label ?? `${size.volume_ml}ml`
+                        size.sizes?.name ?? `${size.sizes?.volume_ml ?? 0}ml`
                       })`,
                       slug: cocktail.id,
                       image: cocktail.image_url ?? "/images/placeholder.webp",

--- a/src/components/cart/AddToCartButton.tsx
+++ b/src/components/cart/AddToCartButton.tsx
@@ -8,9 +8,11 @@ import { supabase } from "@/lib/supabaseClient";
 
 interface CocktailSize {
   id: string;
-  label: string | null;
-  volume_ml: number | null;
   price: number;
+  sizes: {
+    name: string | null;
+    volume_ml: number | null;
+  } | null;
 }
 
 export default function AddToCartButton({ product }: { product: Product }) {
@@ -23,7 +25,7 @@ export default function AddToCartButton({ product }: { product: Product }) {
     setLoading(true);
     const { data, error } = await supabase
       .from("cocktail_sizes")
-      .select("id, label, volume_ml, price")
+      .select(`id, price, sizes ( name, volume_ml )`)
       .eq("cocktail_id", product.slug)
       .eq("available", true);
     if (!error && data) setSizes(data);
@@ -38,7 +40,9 @@ export default function AddToCartButton({ product }: { product: Product }) {
   function handleSelect(size: CocktailSize) {
     addToCart({
       id: size.id,
-      name: `${product.name} (${size.label ?? `${size.volume_ml}ml`})`,
+      name: `${product.name} (${
+        size.sizes?.name ?? `${size.sizes?.volume_ml ?? 0}ml`
+      })`,
       slug: product.slug,
       image: product.image,
       description: product.description,
@@ -83,7 +87,9 @@ export default function AddToCartButton({ product }: { product: Product }) {
                   onClick={() => handleSelect(size)}
                   className="w-full flex justify-between items-center border border-cosmic-gold rounded px-4 py-2 text-cosmic-text hover:bg-cosmic-gold/20"
                 >
-                  <span>{size.label ?? `${size.volume_ml}ml`}</span>
+                  <span>
+                    {size.sizes?.name ?? `${size.sizes?.volume_ml ?? 0}ml`}
+                  </span>
                   <span>€{size.price.toFixed(2)}</span>
                 </button>
               ))}


### PR DESCRIPTION
## Summary
- correctly join `sizes` table when fetching cocktail sizes
- update Add to Cart button and cocktail detail page to use joined size data

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685170a80a48832f9aa6aaf0b5d8b6c4