### PR TITLE
Optimize account images and cache static assets

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -85,6 +85,15 @@ const nextConfig = {
           },
         ],
       },
+      {
+        source: "/images/(.*)",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=31536000, immutable",
+          },
+        ],
+      },
     ];
   },
 

--- a/src/app/order/[id]/page.tsx
+++ b/src/app/order/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import Image from "next/image";
 import { createClient } from "@/lib/supabase/client";
 import OrderDetailActions from "@/components/order/OrderDetailActions";
 import OrderTitle from "@/components/order/OrderTitle";
@@ -175,10 +176,11 @@ export default function OrderDetailPage({
                 >
                   <div className="flex items-center gap-4">
                     {it.cocktail_image && (
-                      // eslint-disable-next-line @next/next/no-img-element
-                      <img
+                      <Image
                         src={it.cocktail_image}
                         alt={it.cocktail_name ?? "cocktail"}
+                        width={48}
+                        height={48}
                         className="w-12 h-12 rounded-lg object-cover border border-cosmic-gold/20"
                       />
                     )}

--- a/src/components/account/UserFavorites.tsx
+++ b/src/components/account/UserFavorites.tsx
@@ -10,6 +10,7 @@ import {
   HiOutlineEye,
 } from "react-icons/hi2";
 import { useLanguage } from "@/contexts/LanguageContext";
+import Image from "next/image";
 
 interface FavoriteCocktail {
   id: string;
@@ -122,10 +123,12 @@ export default function UserFavorites() {
             >
               {/* Image */}
               <div className="relative h-48 bg-gray-200">
-                <img
+                <Image
                   src={cocktail.image_url}
                   alt={cocktail.name}
-                  className="w-full h-full object-cover"
+                  fill
+                  sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+                  className="object-cover"
                 />
                 <div className="absolute top-4 right-4">
                   <button

--- a/src/components/account/UserOrders.tsx
+++ b/src/components/account/UserOrders.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useLanguage } from "@/contexts/LanguageContext";
+import Image from "next/image";
 import {
   HiOutlineShoppingBag,
   HiOutlineClock,
@@ -205,12 +206,14 @@ export default function UserOrders() {
                     {order.items.slice(0, 3).map((item, index) => (
                       <div
                         key={index}
-                        className="w-10 h-10 rounded-full border-2 border-white overflow-hidden"
+                        className="relative w-10 h-10 rounded-full border-2 border-white overflow-hidden"
                       >
-                        <img
+                        <Image
                           src={item.image_url}
                           alt={item.cocktail_name}
-                          className="w-full h-full object-cover"
+                          fill
+                          sizes="40px"
+                          className="object-cover"
                         />
                       </div>
                     ))}


### PR DESCRIPTION
## Summary
- replace account/order <img> tags with Next Image for optimized loading
- add long-term caching headers for /images assets

Closes #30