### PR TITLE
Guard cart views until hydration

### DIFF
--- a/src/components/cart/CartClient.tsx
+++ b/src/components/cart/CartClient.tsx
@@ -17,10 +17,11 @@ export default function CartClient() {
     clearCart,
     isLoading,
     error,
+    hasHydrated,
   } = useCart();
 
   // Wait for language context to be initialized
-  if (!isInitialized) {
+  if (!isInitialized || !hasHydrated) {
     return (
       <main className="py-20 px-6 min-h-[70vh] flex items-center justify-center">
         <div className="text-center">

--- a/src/components/checkout/CheckoutClient.tsx
+++ b/src/components/checkout/CheckoutClient.tsx
@@ -33,6 +33,7 @@ export default function CheckoutClient() {
     clearCart,
     isLoading,
     error,
+    hasHydrated,
   } = useCart();
 
   const { getFormDataForEmail, saveClientData } = useClientData();
@@ -248,6 +249,17 @@ export default function CheckoutClient() {
 
   // El pago se maneja a través de StripePaymentComplete
   // No necesitamos handleSubmit aquí
+
+  if (!hasHydrated) {
+    return (
+      <main className="py-20 px-6 min-h-[70vh] flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-cosmic-gold mx-auto mb-4"></div>
+          <p className="text-cosmic-fog">{t("checkout.loading")}</p>
+        </div>
+      </main>
+    );
+  }
 
   if (isLoading) {
     return (

--- a/src/store/cart.ts
+++ b/src/store/cart.ts
@@ -13,6 +13,8 @@ interface CartState extends Cart {
   ) => void;
   clearCart: () => void;
   recalculateTotals: () => void;
+  hasHydrated: boolean;
+  setHasHydrated: (value: boolean) => void;
 
   // Estado de carga
   isLoading: boolean;
@@ -33,6 +35,7 @@ export const useCart = create<CartState>()(
       shipping_cost: 0,
       total: 0,
       item_count: 0,
+      hasHydrated: false,
       isLoading: false,
       error: null,
 
@@ -152,6 +155,9 @@ export const useCart = create<CartState>()(
           item_count,
         });
       },
+      setHasHydrated: value => {
+        set({ hasHydrated: value });
+      },
     }),
     {
       name: "cosmic-cocktails-cart",
@@ -164,6 +170,12 @@ export const useCart = create<CartState>()(
         total: state.total,
         item_count: state.item_count,
       }),
+      onRehydrateStorage: () => (state, error) => {
+        if (error) {
+          console.error("Error rehydrating cart:", error);
+        }
+        state?.setHasHydrated(true);
+      },
     }
   )
 );


### PR DESCRIPTION
## Summary
- add a cart hydration flag in the zustand store
- gate cart and checkout views until persisted cart is loaded
- avoid empty-cart flashes on refresh/language change

Refs #31
Relates to #67, #92
