### PR TITLE
Checkout: remove duplicate phone field

### DIFF
--- a/src/components/checkout/AddressForm.tsx
+++ b/src/components/checkout/AddressForm.tsx
@@ -372,7 +372,9 @@ export default function AddressForm({
                 <p className="text-sm text-cosmic-fog">
                   {address.city}, {address.postal_code}, {address.country}
                 </p>
-                <p className="text-sm text-cosmic-fog">{address.phone}</p>
+                {address.phone && (
+                  <p className="text-sm text-cosmic-fog">{address.phone}</p>
+                )}
               </div>
               <div className="flex gap-2 ml-4">
                 <button
@@ -421,7 +423,7 @@ export default function AddressForm({
           </h3>
 
           <form onSubmit={handleSubmit} className="space-y-4">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 gap-4">
               <div>
                 <label className="block text-sm text-cosmic-fog mb-2">
                   {t("checkout.address_name")} *
@@ -433,19 +435,6 @@ export default function AddressForm({
                   className="w-full bg-transparent border border-cosmic-fog/30 rounded-md p-3 focus:border-cosmic-gold focus:outline-none transition"
                   value={formData.name}
                   onChange={e => handleInputChange("name", e.target.value)}
-                />
-              </div>
-              <div>
-                <label className="block text-sm text-cosmic-fog mb-2">
-                  {t("checkout.phone")} *
-                </label>
-                <input
-                  type="tel"
-                  required
-                  placeholder={t("checkout.phone_placeholder")}
-                  className="w-full bg-transparent border border-cosmic-fog/30 rounded-md p-3 focus:border-cosmic-gold focus:outline-none transition"
-                  value={formData.phone}
-                  onChange={e => handleInputChange("phone", e.target.value)}
                 />
               </div>
             </div>

--- a/src/components/checkout/CheckoutClient.tsx
+++ b/src/components/checkout/CheckoutClient.tsx
@@ -161,11 +161,18 @@ export default function CheckoutClient() {
     setSelectedAddress(address);
   };
 
+  const addressWithPhone = selectedAddress
+    ? {
+        ...selectedAddress,
+        phone: selectedAddress.phone || form.phone,
+      }
+    : selectedAddress;
+
   const createPaymentIntent = async () => {
     try {
       console.log("🔍 Creating payment intent with data:", {
         items,
-        address: selectedAddress,
+        address: addressWithPhone,
         form: { name: form.name, email: form.email },
       });
 
@@ -176,7 +183,7 @@ export default function CheckoutClient() {
         },
         body: JSON.stringify({
           items: items,
-          address: selectedAddress,
+          address: addressWithPhone,
         }),
       });
 
@@ -218,7 +225,7 @@ export default function CheckoutClient() {
           email: form.email,
           full_name: form.name,
           phone: form.phone,
-          address: selectedAddress,
+          address: addressWithPhone,
           is_guest: true,
           user_id: undefined,
         });
@@ -242,7 +249,7 @@ export default function CheckoutClient() {
         shipping_cost,
         total,
         item_count,
-        shippingAddress: selectedAddress,
+        shippingAddress: addressWithPhone,
       };
       sessionStorage.setItem(
         "checkout-success",
@@ -703,7 +710,7 @@ export default function CheckoutClient() {
                   items={items}
                   total={total}
                   user={authUser}
-                  shippingAddress={selectedAddress}
+                  shippingAddress={addressWithPhone}
                   contactEmail={form.email}
                   onPaymentSuccess={handlePaymentSuccess}
                   onPaymentError={handlePaymentError}


### PR DESCRIPTION
## Resumen\n- Elimina el campo de teléfono del formulario de dirección para evitar duplicidad con el paso de contacto.\n- Reutiliza el teléfono del contacto al crear la dirección de envío y el pedido.\n\n## Verificación\n- npm run build\n