### PR TITLE
Stripe: limitar métodos y modo prueba

### DIFF
--- a/src/app/api/create-payment-intent/route.ts
+++ b/src/app/api/create-payment-intent/route.ts
@@ -57,9 +57,7 @@ export async function POST(request: NextRequest) {
     const paymentIntent = await stripe.paymentIntents.create({
       amount: total,
       currency: "eur",
-      automatic_payment_methods: {
-        enabled: true,
-      },
+      payment_method_types: ["card", "ideal"],
       metadata: {
         items_count: items.length.toString(),
         subtotal: subtotal.toString(),

--- a/src/components/checkout/CheckoutClient.tsx
+++ b/src/components/checkout/CheckoutClient.tsx
@@ -42,7 +42,8 @@ export default function CheckoutClient() {
   const allowTestPayments =
     envClient.NEXT_PUBLIC_STRIPE_ALLOW_TEST_PAYMENTS === "true";
   const stripeMode = isTestKey ? "test" : "live";
-  const stripeEnabled = stripeMode === "live" || allowTestPayments;
+  const stripePaymentsEnabled =
+    stripeMode === "live" || allowTestPayments;
 
   const [form, setForm] = useState({
     name: "",
@@ -290,7 +291,6 @@ export default function CheckoutClient() {
       form.email &&
       privacyAccepted &&
       currentStep >= 3 &&
-      stripeEnabled &&
       !clientSecret
     ) {
       console.log("🚀 Creating payment intent...");
@@ -305,13 +305,11 @@ export default function CheckoutClient() {
               ? "no name provided"
               : !form.email
                 ? "no email provided"
-                : !privacyAccepted
-                  ? "privacy consent not accepted"
-                  : !stripeEnabled
-                    ? "stripe disabled"
-                  : clientSecret
-                    ? "already has client secret"
-                    : "unknown",
+                  : !privacyAccepted
+                    ? "privacy consent not accepted"
+                    : clientSecret
+                      ? "already has client secret"
+                      : "unknown",
       });
     }
   }, [
@@ -322,7 +320,6 @@ export default function CheckoutClient() {
     privacyAccepted,
     clientSecret,
     currentStep,
-    stripeEnabled,
   ]);
 
   const handleInventoryValidation = (
@@ -706,11 +703,13 @@ export default function CheckoutClient() {
                 </div>
               )}
 
-              {!stripeEnabled ? (
-                <div className="bg-cosmic-fog/10 rounded-lg p-4 text-center text-sm text-cosmic-fog">
+              {!stripePaymentsEnabled && (
+                <div className="mb-4 rounded-lg border border-cosmic-gold/30 bg-cosmic-gold/10 p-3 text-sm text-cosmic-gold">
                   {t("checkout.stripe_payments_disabled")}
                 </div>
-              ) : clientSecret && privacyAccepted ? (
+              )}
+
+              {clientSecret && privacyAccepted ? (
                 <StripePaymentComplete
                   clientSecret={clientSecret}
                   items={items}
@@ -718,6 +717,7 @@ export default function CheckoutClient() {
                   user={authUser}
                   shippingAddress={addressWithPhone}
                   contactEmail={form.email}
+                  paymentsEnabled={stripePaymentsEnabled}
                   onPaymentSuccess={handlePaymentSuccess}
                   onPaymentError={handlePaymentError}
                 />

--- a/src/components/checkout/StripePaymentComplete.tsx
+++ b/src/components/checkout/StripePaymentComplete.tsx
@@ -24,6 +24,7 @@ interface StripePaymentCompleteProps {
   user?: any;
   shippingAddress?: any;
   contactEmail?: string;
+  paymentsEnabled?: boolean;
   onPaymentSuccess: (payload: {
     orderId: string;
     orderRef?: string;
@@ -39,6 +40,7 @@ function PaymentForm({
   user,
   shippingAddress,
   contactEmail,
+  paymentsEnabled = true,
   onPaymentSuccess,
   onPaymentError,
 }: StripePaymentCompleteProps) {
@@ -54,6 +56,11 @@ function PaymentForm({
 
   useEffect(() => {
     if (!stripe || !clientSecret) return;
+    if (!paymentsEnabled) {
+      setPaymentRequest(null);
+      setCanUsePaymentRequest(false);
+      return;
+    }
     let isMounted = true;
     const pr = stripe.paymentRequest({
       country: "NL",
@@ -149,6 +156,11 @@ function PaymentForm({
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
 
+    if (!paymentsEnabled) {
+      setError(t("checkout.stripe_payments_locked"));
+      onPaymentError(t("checkout.stripe_payments_locked"));
+      return;
+    }
     if (!stripe || !elements) {
       return;
     }
@@ -244,12 +256,12 @@ function PaymentForm({
         </div>
 
         <div className="space-y-4">
-          {canUsePaymentRequest && paymentRequest && (
+          {paymentsEnabled && canUsePaymentRequest && paymentRequest && (
             <div className="space-y-3">
               <div className="flex items-center gap-3 text-xs uppercase tracking-[0.2em] text-cosmic-silver">
-                <span className="h-[1px] flex-1 bg-cosmic-gold/20" />
+                <span className="h-[1px] flex-1 bg-gradient-to-r from-transparent via-cosmic-gold/40 to-transparent" />
                 <span>{t("checkout.express_wallets")}</span>
-                <span className="h-[1px] flex-1 bg-cosmic-gold/20" />
+                <span className="h-[1px] flex-1 bg-gradient-to-r from-transparent via-cosmic-gold/40 to-transparent" />
               </div>
               <PaymentRequestButtonElement
                 options={{
@@ -295,7 +307,7 @@ function PaymentForm({
 
         <button
           type="submit"
-          disabled={!stripe || isLoading || isCreatingOrder}
+          disabled={!stripe || isLoading || isCreatingOrder || !paymentsEnabled}
           className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700 text-white font-medium rounded-lg transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {isCreatingOrder ? (
@@ -307,6 +319,11 @@ function PaymentForm({
             <>
               <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white"></div>
               {t("checkout.processing_payment")}
+            </>
+          ) : !paymentsEnabled ? (
+            <>
+              <Lock className="w-4 h-4" />
+              {t("checkout.stripe_payments_locked")}
             </>
           ) : (
             <>
@@ -327,6 +344,7 @@ export default function StripePaymentComplete({
   user,
   shippingAddress,
   contactEmail,
+  paymentsEnabled,
   onPaymentSuccess,
   onPaymentError,
 }: StripePaymentCompleteProps) {
@@ -359,6 +377,7 @@ export default function StripePaymentComplete({
         user={user}
         shippingAddress={shippingAddress}
         contactEmail={contactEmail}
+        paymentsEnabled={paymentsEnabled}
         onPaymentSuccess={onPaymentSuccess}
         onPaymentError={onPaymentError}
       />

--- a/src/i18n/translations/en.ts
+++ b/src/i18n/translations/en.ts
@@ -361,6 +361,7 @@ const en = {
     "privacy_consent_required": "Please accept the privacy policy to continue.",
     "stripe_test_mode": "Test mode",
     "stripe_payments_disabled": "Stripe is in test mode. Payments are disabled until live keys are configured.",
+    "stripe_payments_locked": "Payments disabled",
     "preparing_payment": "Preparing secure payment...",
     "express_wallets": "Apple Pay / Google Pay",
     "products_unavailable": "Some products are not available. Check your cart.",

--- a/src/i18n/translations/es.ts
+++ b/src/i18n/translations/es.ts
@@ -364,6 +364,7 @@ const es = {
     "privacy_consent_required": "Debes aceptar la política de privacidad para continuar.",
     "stripe_test_mode": "Modo prueba",
     "stripe_payments_disabled": "Stripe está en modo prueba. Los pagos están desactivados hasta configurar claves live.",
+    "stripe_payments_locked": "Pagos desactivados",
     "preparing_payment": "Preparando pago seguro...",
     "express_wallets": "Apple Pay / Google Pay",
     "products_unavailable": "Algunos productos no están disponibles. Revisa tu carrito.",

--- a/src/i18n/translations/nl.ts
+++ b/src/i18n/translations/nl.ts
@@ -366,6 +366,7 @@ const nl = {
     "privacy_consent_required": "Accepteer de privacyverklaring om verder te gaan.",
     "stripe_test_mode": "Testmodus",
     "stripe_payments_disabled": "Stripe staat in testmodus. Betalingen zijn uitgeschakeld totdat live-sleutels zijn ingesteld.",
+    "stripe_payments_locked": "Betalingen uitgeschakeld",
     "preparing_payment": "Veilige betaling voorbereiden...",
     "express_wallets": "Apple Pay / Google Pay",
     "products_unavailable": "Sommige producten zijn niet beschikbaar. Controleer je winkelwagen.",


### PR DESCRIPTION
## Resumen
- Limita PaymentIntent a card + iDEAL para quitar Bancontact/EPS.
- Apple/Google Pay separado con Payment Request Button.
- Modo test: muestra formulario pero bloquea pago si no se habilita.

## Issues
- Relacionado con #33 y #50.