### PR TITLE
Stripe: fix build + webhook order insert

### DIFF
--- a/src/components/checkout/StripePaymentComplete.tsx
+++ b/src/components/checkout/StripePaymentComplete.tsx
@@ -13,7 +13,7 @@ import {
 import { CreditCard, Lock, AlertTriangle, CheckCircle } from "lucide-react";
 import { CartItem } from "@/types/shared";
 import { useLanguage } from "@/contexts/LanguageContext";
-import type { StripePaymentRequest } from "@stripe/stripe-js";
+import type { PaymentRequest } from "@stripe/stripe-js";
 
 const stripePromise = loadStripe(envClient.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY);
 
@@ -51,7 +51,7 @@ function PaymentForm({
   const [error, setError] = useState<string | null>(null);
   const [isCreatingOrder, setIsCreatingOrder] = useState(false);
   const [paymentRequest, setPaymentRequest] =
-    useState<StripePaymentRequest | null>(null);
+    useState<PaymentRequest | null>(null);
   const [canUsePaymentRequest, setCanUsePaymentRequest] = useState(false);
 
   useEffect(() => {


### PR DESCRIPTION
## Resumen
- Corrige el type import de StripePaymentRequest -> PaymentRequest.
- Webhook crea pedidos directamente (UUID) sin RPC y registra errores en security_events.

## Contexto
- Evita fallos de build en Vercel y asegura pedidos en modo iDEAL/redirect.