### PR TITLE
Fix Vercel build: remove paymentMethodOrder

### DIFF
--- a/src/components/checkout/StripePaymentComplete.tsx
+++ b/src/components/checkout/StripePaymentComplete.tsx
@@ -367,7 +367,6 @@ export default function StripePaymentComplete({
       stripe={stripePromise}
       options={{
         clientSecret,
-        paymentMethodOrder: ["apple_pay", "google_pay", "card", "ideal"],
       }}
     >
       <PaymentForm


### PR DESCRIPTION
Removes unsupported `paymentMethodOrder` from Stripe Elements options to fix typecheck in Vercel.