### PR TITLE
Fix Vercel: mark /api/orders dynamic

### DIFF
--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 
+export const dynamic = "force-dynamic";
+
 export async function GET(request: NextRequest) {
   try {
     const supabase = createClient();


### PR DESCRIPTION
Adds `export const dynamic = "force-dynamic"` to /api/orders to avoid static rendering warnings/errors in Vercel build.