### PR TITLE
Fix orders API select for legacy schema

### DIFF
--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -22,7 +22,7 @@ export async function GET(request: NextRequest) {
     const limit = limitParam ? Number(limitParam) : null;
 
     const baseSelect =
-      "id, total_amount, status, order_date, delivery_date, created_at";
+      "id, total_amount, status, order_date, delivery_date";
     const summarySelect = `${baseSelect},
          order_items ( id )`;
 


### PR DESCRIPTION
## Summary
- avoid selecting missing columns in `/api/orders` for legacy schema

## Testing
- manual: account orders and dashboard stats