### PR TITLE
Account: add addresses tab

### DIFF
--- a/src/components/account/AccountTabs.tsx
+++ b/src/components/account/AccountTabs.tsx
@@ -31,6 +31,12 @@ const UserFavorites = dynamic(() => import("./UserFavorites"), {
     <div className="h-64 w-full animate-pulse bg-white/10 rounded-xl" />
   ),
 });
+const UserAddresses = dynamic(() => import("./UserAddresses"), {
+  ssr: true,
+  loading: () => (
+    <div className="h-64 w-full animate-pulse bg-white/10 rounded-xl" />
+  ),
+});
 const UserSettings = dynamic(() => import("./UserSettings"), {
   ssr: true,
   loading: () => (
@@ -43,6 +49,7 @@ import {
   HiOutlineShoppingBag,
   HiOutlineHeart,
   HiOutlineCog,
+  HiOutlineMapPin,
   HiXMark,
 } from "react-icons/hi2";
 
@@ -65,6 +72,11 @@ const getTabs = (t: (key: string) => string) => {
       id: "favorites",
       name: t("account.tabs.favorites"),
       icon: HiOutlineHeart,
+    },
+    {
+      id: "addresses",
+      name: t("account.tabs.addresses"),
+      icon: HiOutlineMapPin,
     },
     { id: "settings", name: t("account.tabs.settings"), icon: HiOutlineCog },
   ];
@@ -134,6 +146,8 @@ export default function AccountTabs({
         return <UserOrders />;
       case "favorites":
         return <UserFavorites />;
+      case "addresses":
+        return <UserAddresses />;
       case "settings":
         return <UserSettings user={user} onUpdate={onUpdate} />;
       default:

--- a/src/components/account/UserAddresses.tsx
+++ b/src/components/account/UserAddresses.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useState } from "react";
+import { HiOutlineMapPin } from "react-icons/hi2";
+import AddressForm from "@/components/checkout/AddressForm";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { useAuthUnified } from "@/hooks/useAuthUnified";
+import { Address } from "@/types/shared";
+
+export default function UserAddresses() {
+  const { t } = useLanguage();
+  const { user } = useAuthUnified();
+  const [selectedAddress, setSelectedAddress] = useState<Address | null>(null);
+
+  return (
+    <div className="space-y-6">
+      <div className="bg-white/5 backdrop-blur-md rounded-lg border border-sky-500/30 shadow-[0_0_24px_rgba(59,130,246,.12)] p-6">
+        <h2 className="text-2xl font-bold text-slate-100 flex items-center">
+          <HiOutlineMapPin className="h-6 w-6 mr-3 text-cosmic-gold" />
+          {t("account.addresses_title")}
+        </h2>
+        <p className="text-slate-300 mt-2">
+          {t("account.addresses_subtitle")}
+        </p>
+      </div>
+
+      <AddressForm
+        onAddressSelect={setSelectedAddress}
+        selectedAddress={selectedAddress}
+        isAuthenticated={Boolean(user)}
+        savePrompt={false}
+      />
+    </div>
+  );
+}

--- a/src/components/checkout/AddressForm.tsx
+++ b/src/components/checkout/AddressForm.tsx
@@ -10,6 +10,7 @@ interface AddressFormProps {
   onAddressSelect: (address: Address | null) => void;
   selectedAddress?: Address | null;
   isAuthenticated?: boolean;
+  savePrompt?: boolean;
 }
 
 interface AddressFormData {
@@ -60,6 +61,7 @@ export default function AddressForm({
   onAddressSelect,
   selectedAddress,
   isAuthenticated = false,
+  savePrompt = true,
 }: AddressFormProps) {
   const { t } = useLanguage();
   const { notify } = useToast();
@@ -359,6 +361,17 @@ export default function AddressForm({
       };
       upsertLocalAddress(tempAddress, true, "updated");
       resetFormState();
+      return;
+    }
+
+    if (!savePrompt) {
+      void saveAddressToAccount(
+        {
+          ...baseAddress,
+          is_default: shouldBeDefault,
+        },
+        false
+      );
       return;
     }
 

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -11,6 +11,7 @@ import {
   HiOutlineUser,
   HiOutlineShoppingBag,
   HiOutlineHeart,
+  HiOutlineMapPin,
   HiOutlineCog,
   HiOutlineCog6Tooth,
   HiXMark,
@@ -237,6 +238,12 @@ export default function Navbar() {
         name: t("account.tabs.favorites"),
         icon: HiOutlineHeart,
         href: "/account?tab=favorites",
+      },
+      {
+        id: "addresses",
+        name: t("account.tabs.addresses"),
+        icon: HiOutlineMapPin,
+        href: "/account?tab=addresses",
       },
       {
         id: "settings",

--- a/src/i18n/translations/en.ts
+++ b/src/i18n/translations/en.ts
@@ -705,9 +705,12 @@ const en = {
       "profile": "Profile",
       "orders": "Orders",
       "favorites": "Favorites",
+      "addresses": "Addresses",
       "settings": "Settings",
       "admin": "Admin Panel"
-    }
+    },
+    "addresses_title": "Saved Addresses",
+    "addresses_subtitle": "Manage your shipping addresses for faster checkout."
   },
   "orders": {
     "title": "My Orders",

--- a/src/i18n/translations/es.ts
+++ b/src/i18n/translations/es.ts
@@ -661,9 +661,12 @@ const es = {
       "profile": "Perfil",
       "orders": "Pedidos",
       "favorites": "Favoritos",
+      "addresses": "Direcciones",
       "settings": "Configuración",
       "admin": "Panel de Administración"
-    }
+    },
+    "addresses_title": "Direcciones guardadas",
+    "addresses_subtitle": "Gestiona tus direcciones de envío para pagar más rápido."
   },
   "orders": {
     "title": "Mis Pedidos",

--- a/src/i18n/translations/nl.ts
+++ b/src/i18n/translations/nl.ts
@@ -487,9 +487,12 @@ const nl = {
       "profile": "Profiel",
       "orders": "Bestellingen",
       "favorites": "Favorieten",
+      "addresses": "Adressen",
       "settings": "Instellingen",
       "admin": "Beheerpaneel"
-    }
+    },
+    "addresses_title": "Opgeslagen adressen",
+    "addresses_subtitle": "Beheer je verzendadressen voor sneller afrekenen."
   },
   "common": {
     "loading": "Laden...",


### PR DESCRIPTION
Adds an Addresses tab in Account, reuses checkout AddressForm without the save prompt, and adds translations.

Closes #91.