### PR TITLE
M0.01 lock down order summary access

### DIFF
--- a/src/app/checkout/success/page.tsx
+++ b/src/app/checkout/success/page.tsx
@@ -154,8 +154,8 @@ export default function CheckoutSuccess() {
   }, [orderId, summary, user]);
 
   useEffect(() => {
+    if (!user) return;
     if (summary || summaryLoading) return;
-    if (user && orderId) return;
     if (!orderId && !paymentIntent) return;
 
     const controller = new AbortController();


### PR DESCRIPTION
Closes #301

- Require auth + ownership on /api/order-summary
- Stop guest fallback to order-summary on checkout success
- Derive order user_id from authenticated session when creating orders