### PR TITLE
M0.03 single source of truth for order creation

### DIFF
--- a/src/app/api/create-order/route.ts
+++ b/src/app/api/create-order/route.ts
@@ -132,6 +132,7 @@ export async function POST(request: NextRequest) {
         user_id: resolvedUserId,
         total_amount: total,
         status: "paid", // Pago confirmado directamente
+        is_paid: true,
         payment_intent_id: payment_intent_id || null,
         shipping_address: JSON.stringify(shipping_address),
       })

--- a/src/lib/orders/handlePaymentSucceeded.ts
+++ b/src/lib/orders/handlePaymentSucceeded.ts
@@ -1,10 +1,5 @@
 import { createClient } from "@supabase/supabase-js";
 import { envServer } from "@/lib/env-server";
-import {
-  normalizeOrderItems,
-  type NormalizedOrderItem,
-  type OrderItemInput,
-} from "@/types/order-item-utils";
 
 type Args = {
   paymentIntentId: string;
@@ -12,7 +7,7 @@ type Args = {
   metadata: Record<string, string>;
 };
 
-// Creates order and decrements stock in a best-effort atomic way using Postgres RPC
+// Webhook handler: ensure the existing order is marked as paid (no order creation here)
 export async function handlePaymentSucceeded({
   paymentIntentId,
   amountReceived,
@@ -23,127 +18,51 @@ export async function handlePaymentSucceeded({
     envServer.SUPABASE_SERVICE_ROLE_KEY
   );
 
-  if (paymentIntentId) {
-    const { data: existingOrder, error: existingError } = await (supabase as any)
-      .from("orders")
-      .select("id")
-      .eq("payment_intent_id", paymentIntentId)
-      .maybeSingle();
-
-    if (existingError) {
-      await (supabase as any).from("security_events").insert({
-        type: "payment_intent_succeeded_order_check_error",
-        payload: {
-          payment_intent_id: paymentIntentId,
-          error: existingError.message,
-        },
-      });
-    }
-
-    if (existingOrder) {
-      return;
-    }
-  }
-
-  // Parse items from metadata (created earlier)
-  let items: OrderItemInput[] = [];
-  try {
-    if (metadata.items) {
-      items = JSON.parse(metadata.items.replace(/\.\.\.__truncated$/, ""));
-    }
-  } catch {
-    items = [];
-  }
-
-  let normalizedItems: NormalizedOrderItem[] = [];
-  try {
-    normalizedItems = normalizeOrderItems(items);
-  } catch {
-    normalizedItems = [];
-  }
-
-  // Fallback: if items missing, do nothing but record event
-  if (!normalizedItems.length) {
-    await (supabase as any).from("security_events").insert({
-      type: "payment_intent_succeeded_no_items",
-      payload: { payment_intent_id: paymentIntentId, amount: amountReceived },
-    });
+  if (!paymentIntentId) {
     return;
   }
 
   const { data: order, error: orderError } = await (supabase as any)
     .from("orders")
-    .insert({
-      total_amount: amountReceived / 100,
-      status: "paid",
-      is_paid: true,
-      payment_intent_id: paymentIntentId,
-    })
-    .select()
-    .single();
+    .select("id, status, is_paid")
+    .eq("payment_intent_id", paymentIntentId)
+    .maybeSingle();
 
   if (orderError) {
     await (supabase as any).from("security_events").insert({
-      type: "payment_intent_succeeded_order_error",
+      type: "payment_intent_succeeded_order_check_error",
       payload: { payment_intent_id: paymentIntentId, error: orderError.message },
     });
-    throw new Error(orderError.message);
+    return;
   }
 
-  const orderItems = normalizedItems.map(item => ({
-    order_id: order.id,
-    cocktail_id: item.cocktail_id,
-    size_id: item.sizes_id,
-    quantity: item.quantity,
-    unit_price: item.unit_price,
-    item_total: item.item_total ?? item.unit_price * item.quantity,
-  }));
-
-  const { error: itemsError } = await (supabase as any)
-    .from("order_items")
-    .insert(orderItems);
-
-  if (itemsError) {
+  if (!order) {
     await (supabase as any).from("security_events").insert({
-      type: "payment_intent_succeeded_items_error",
-      payload: { payment_intent_id: paymentIntentId, error: itemsError.message },
+      type: "payment_intent_succeeded_missing_order",
+      payload: { payment_intent_id: paymentIntentId, amount: amountReceived, metadata },
     });
-    throw new Error(itemsError.message);
+    return;
   }
 
-  for (const item of normalizedItems) {
-    const { data: currentStock, error: fetchError } = await (supabase as any)
-      .from("cocktail_sizes")
-      .select("stock_quantity")
-      .eq("cocktail_id", item.cocktail_id)
-      .eq("sizes_id", item.sizes_id)
-      .single();
+  const updates: Record<string, unknown> = {};
+  if (order.is_paid !== true) {
+    updates.is_paid = true;
+  }
+  if (order.status !== "paid") {
+    updates.status = "paid";
+  }
 
-    if (fetchError) {
+  if (Object.keys(updates).length > 0) {
+    const { error: updateError } = await (supabase as any)
+      .from("orders")
+      .update(updates)
+      .eq("id", order.id);
+
+    if (updateError) {
       await (supabase as any).from("security_events").insert({
-        type: "payment_intent_succeeded_stock_fetch_error",
-        payload: { payment_intent_id: paymentIntentId, error: fetchError.message },
-      });
-      continue;
-    }
-
-    const newStock = (currentStock?.stock_quantity || 0) - item.quantity;
-    const isAvailable = newStock > 0;
-
-    const { error: stockError } = await (supabase as any)
-      .from("cocktail_sizes")
-      .update({ stock_quantity: newStock, available: isAvailable })
-      .eq("cocktail_id", item.cocktail_id)
-      .eq("sizes_id", item.sizes_id);
-
-    if (stockError) {
-      await (supabase as any).from("security_events").insert({
-        type: "payment_intent_succeeded_stock_update_error",
-        payload: { payment_intent_id: paymentIntentId, error: stockError.message },
+        type: "payment_intent_succeeded_order_update_error",
+        payload: { payment_intent_id: paymentIntentId, error: updateError.message },
       });
     }
   }
-
-  // No necesitamos actualizar de 'ordered' a 'paid' porque ahora creamos directamente en 'paid'
-  // El RPC ya crea el pedido con status 'paid'
 }


### PR DESCRIPTION
Closes #302

- Make /api/create-order the canonical order creation flow
- Stripe webhook now only marks existing orders as paid or logs missing orders
- Ensure orders created via API set is_paid=true

Tests: `npm run lint`