### PR TITLE
M0.05: Harden checkout privacy and Stripe confirmation

### DIFF
--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -159,18 +159,6 @@ async function performSecurityChecks(data: {
 /**
  * Envía el mensaje de contacto
  */
-const maskEmail = (email: string) => {
-  const [name, domain] = email.split("@");
-  if (!domain) return "***";
-  return `${name.slice(0, 1)}***@${domain}`;
-};
-
-const maskPhone = (phone: string) => {
-  const digits = phone.replace(/\D/g, "");
-  if (digits.length <= 2) return "***";
-  return `${"*".repeat(digits.length - 2)}${digits.slice(-2)}`;
-};
-
 const maskIp = (ip: string) => {
   if (!ip) return "***";
   if (ip.includes(".")) {
@@ -209,8 +197,6 @@ async function sendContactMessage(data: {
       );
       console.log("📧 Contact message received:", {
         messageId,
-        email: maskEmail(data.email),
-        phone: data.phone ? maskPhone(data.phone) : null,
         subjectLength: data.subject.length,
         messageLength: data.message.length,
         ip: maskIp(data.ip),

--- a/src/app/api/create-order/route.ts
+++ b/src/app/api/create-order/route.ts
@@ -230,12 +230,6 @@ export async function POST(request: NextRequest) {
   }
 }
 
-function maskEmail(email: string) {
-  const [name, domain] = email.split("@");
-  if (!domain) return "***";
-  return `${name.slice(0, 2)}***@${domain}`;
-}
-
 async function sendOrderConfirmation(data: {
   email: string;
   orderId: string;
@@ -246,7 +240,6 @@ async function sendOrderConfirmation(data: {
   try {
     // Placeholder for real email delivery (Resend/SendGrid/etc.).
     console.log("📧 Order confirmation queued:", {
-      email: maskEmail(data.email),
       orderId: data.orderId,
       orderRef: data.orderRef,
       total: data.total,

--- a/src/app/api/create-payment-intent/route.ts
+++ b/src/app/api/create-payment-intent/route.ts
@@ -43,7 +43,8 @@ const aggregateInventoryItems = (
 export async function POST(request: NextRequest) {
   try {
     console.log("🔍 Creating payment intent...");
-    const { items, privacyAccepted, address } = await request.json();
+    const { items, privacyAccepted, address, checkoutAttemptId } =
+      await request.json();
 
     if (!items || items.length === 0) {
       console.log("❌ No items provided");
@@ -216,7 +217,12 @@ export async function POST(request: NextRequest) {
       const keyB = `${b.cocktail_id}:${b.sizes_id}`;
       return keyA.localeCompare(keyB);
     });
+    const normalizedAttemptId =
+      typeof checkoutAttemptId === "string"
+        ? checkoutAttemptId.trim()
+        : "";
     const idempotencyPayload = JSON.stringify({
+      attempt_id: normalizedAttemptId || undefined,
       items: sortedItems.map(item => ({
         cocktail_id: item.cocktail_id,
         size_id: item.sizes_id,

--- a/src/app/checkout/success/page.tsx
+++ b/src/app/checkout/success/page.tsx
@@ -52,6 +52,7 @@ export default function CheckoutSuccess() {
     const orderIdFromUrl = urlParams.get("order_id");
     const orderRefFromUrl = urlParams.get("order_ref");
     const paymentIntentFromUrl = urlParams.get("payment_intent");
+    const clientSecretFromUrl = urlParams.get("payment_intent_client_secret");
 
     if (orderIdFromUrl) {
       setOrderId(orderIdFromUrl);
@@ -61,6 +62,15 @@ export default function CheckoutSuccess() {
     }
     if (paymentIntentFromUrl) {
       setPaymentIntent(paymentIntentFromUrl);
+    }
+
+    if (clientSecretFromUrl) {
+      urlParams.delete("payment_intent_client_secret");
+      const query = urlParams.toString();
+      const cleanUrl = query
+        ? `${window.location.pathname}?${query}`
+        : window.location.pathname;
+      window.history.replaceState({}, document.title, cleanUrl);
     }
 
     try {

--- a/src/components/checkout/StripePaymentComplete.tsx
+++ b/src/components/checkout/StripePaymentComplete.tsx
@@ -18,7 +18,10 @@ const stripePromise = loadStripe(envClient.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY);
 const isAlreadySucceeded = (error: unknown) => {
   const intent = (error as { payment_intent?: { status?: string; id?: string } })
     ?.payment_intent;
-  return intent?.status === "succeeded" ? intent : null;
+  if (intent?.status === "succeeded" && typeof intent.id === "string") {
+    return intent;
+  }
+  return null;
 };
 
 interface StripePaymentCompleteProps {

--- a/src/components/order/OrderDetailActions.tsx
+++ b/src/components/order/OrderDetailActions.tsx
@@ -78,7 +78,11 @@ export default function OrderDetailActions({
     if (!message.trim()) return;
 
     // Aquí podrías enviar el mensaje a un sistema de soporte
-    console.log("Mensaje enviado:", { orderId, orderRef, message });
+    console.log("Mensaje enviado:", {
+      orderId,
+      orderRef,
+      messageLength: message.length,
+    });
 
     // Simular envío
     notify({

--- a/src/lib/migrations/migrateUsers.ts
+++ b/src/lib/migrations/migrateUsers.ts
@@ -44,13 +44,17 @@ export async function migrateUsersToSupabaseAuth() {
           });
 
         if (authError) {
-          console.error(`❌ Error creando usuario ${user.email}:`, authError);
+          console.error("❌ Error creando usuario:", {
+            userId: user.id,
+            authError,
+          });
           continue;
         }
 
-        console.log(
-          `✅ Usuario migrado: ${user.email} (ID: ${authUser.user?.id})`
-        );
+        console.log("✅ Usuario migrado:", {
+          userId: user.id,
+          authId: authUser.user?.id,
+        });
 
         // 3. Actualizar referencias en tablas relacionadas
         if (authUser.user?.id) {
@@ -64,7 +68,10 @@ export async function migrateUsersToSupabaseAuth() {
           // (añadir más tablas según sea necesario)
         }
       } catch (error) {
-        console.error(`❌ Error procesando usuario ${user.email}:`, error);
+        console.error("❌ Error procesando usuario:", {
+          userId: user.id,
+          error,
+        });
       }
     }
 
@@ -94,7 +101,7 @@ export async function createDefaultAdmin() {
     if (error) {
       console.error("❌ Error creando admin:", error);
     } else {
-      console.log("✅ Admin creado:", data.user?.email);
+      console.log("✅ Admin creado:", data.user?.id);
     }
   } catch (error) {
     console.error("❌ Error creando admin:", error);

--- a/src/lib/setup/setupAuth.ts
+++ b/src/lib/setup/setupAuth.ts
@@ -38,7 +38,7 @@ export async function setupInitialAuth() {
       return;
     }
 
-    console.log("✅ Admin creado:", data.user?.email);
+    console.log("✅ Admin creado:", data.user?.id);
 
     // 3. Crear usuario de prueba
     const { data: testUser, error: testError } =
@@ -57,12 +57,10 @@ export async function setupInitialAuth() {
     if (testError) {
       console.error("❌ Error creando usuario de prueba:", testError);
     } else {
-      console.log("✅ Usuario de prueba creado:", testUser.user?.email);
+      console.log("✅ Usuario de prueba creado:", testUser.user?.id);
     }
 
     console.log("🎉 Configuración inicial completada");
-    console.log("📧 Admin: admin@cosmococktails.com / admin123456");
-    console.log("📧 Cliente: test@cosmococktails.com / test123456");
   } catch (error) {
     console.error("❌ Error en configuración:", error);
   }
@@ -89,4 +87,3 @@ export async function checkRLSStatus() {
     console.error("❌ Error verificando RLS:", error);
   }
 }
-

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,6 +4,16 @@ import { rateLimitMiddleware } from "@/lib/rate-limiting";
 
 // Secure middleware with minimal, Stripe/Supabase-compatible CSP and security headers
 export async function middleware(request: NextRequest) {
+  const url = request.nextUrl.clone();
+
+  if (
+    url.pathname === "/checkout/success" &&
+    url.searchParams.has("payment_intent_client_secret")
+  ) {
+    url.searchParams.delete("payment_intent_client_secret");
+    return NextResponse.redirect(url);
+  }
+
   // Apply rate limiting first for API routes
   if (request.nextUrl.pathname.startsWith("/api/")) {
     const rateLimitResponse = await rateLimitMiddleware(request);


### PR DESCRIPTION
## Summary
- Remove PII from client storage and server logs where possible.
- Strip `payment_intent_client_secret` from success URL (middleware + client cleanup).
- Avoid double-confirming Stripe PaymentIntents and handle already-succeeded intents.
- Ensure new PaymentIntents per checkout attempt.

## Testing
- Not run (manual checkout test recommended).

Closes #304
