### PR TITLE
M0.08 [CSP] - Harden CSP and remove unsafe-inline

### DIFF
--- a/src/components/providers/QueryProvider.tsx
+++ b/src/components/providers/QueryProvider.tsx
@@ -10,11 +10,15 @@ interface QueryProviderProps {
 }
 
 export default function QueryProvider({ children }: QueryProviderProps) {
+  const devtoolsEnabled =
+    process.env.NODE_ENV === "development" &&
+    process.env.NEXT_PUBLIC_ENABLE_QUERY_DEVTOOLS === "true";
+
   return (
     <QueryClientProvider client={queryClient}>
       {children}
-      {/* DevTools solo en desarrollo */}
-      {process.env.NODE_ENV === "development" && (
+      {/* DevTools solo si se habilita explícitamente */}
+      {devtoolsEnabled && (
         <ReactQueryDevtools initialIsOpen={false} />
       )}
     </QueryClientProvider>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -14,12 +14,15 @@ export async function middleware(request: NextRequest) {
 
   const response = NextResponse.next();
 
-  // Build a minimal CSP compatible with Stripe and Supabase
-  // Use a simple nonce for now (will be improved later)
-  const nonce = "nextjs-nonce";
+  // Build a CSP compatible with Stripe/Supabase, using a per-request nonce
+  const nonce = crypto.randomUUID();
+  const nonceDirective = `'nonce-${nonce}'`;
 
   const stripeJs = "https://js.stripe.com";
   const stripeApi = "https://api.stripe.com";
+  const stripeNetwork = "https://m.stripe.network";
+  const stripeTelemetry = "https://r.stripe.com";
+  const stripeFrames = "https://hooks.stripe.com";
   const vercelInsightsScript = "https://va.vercel-scripts.com";
   const vercelInsightsConnect = "https://vitals.vercel-insights.com";
   const supabaseProjectUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || "";
@@ -27,6 +30,8 @@ export async function middleware(request: NextRequest) {
   const connectSrc = [
     "'self'",
     stripeApi,
+    stripeNetwork,
+    stripeTelemetry,
     vercelInsightsConnect,
     supabaseProjectUrl,
   ]
@@ -35,31 +40,32 @@ export async function middleware(request: NextRequest) {
 
   const isDev = process.env.NODE_ENV === "development";
 
-  // SOLUCIÓN TEMPORAL: Permitir scripts inline en producción para Next.js
-  const scriptSrcParts = [
-    "'self'",
-    "'unsafe-inline'", // Temporal: permitir scripts inline
-    stripeJs,
-    vercelInsightsScript,
-  ];
+  const scriptSrcParts = ["'self'", nonceDirective, stripeJs, vercelInsightsScript];
 
   // Next.js dev server uses eval for source maps; permit only in development
   if (isDev) {
     scriptSrcParts.push("'unsafe-eval'");
+    scriptSrcParts.push("'unsafe-inline'");
   }
 
   const scriptSrc = scriptSrcParts.join(" ");
 
   const imgSrc = "'self' data: https: blob:";
+  const styleSrcParts = ["'self'", nonceDirective];
+  if (isDev) {
+    styleSrcParts.push("'unsafe-inline'");
+  }
+  const styleSrc = styleSrcParts.join(" ");
 
   const csp = [
     "default-src 'self'",
     `script-src ${scriptSrc}`,
-    "style-src 'self' 'unsafe-inline'",
+    `style-src ${styleSrc}`,
+    "style-src-attr 'unsafe-inline'",
     `connect-src ${connectSrc}`,
     "img-src " + imgSrc,
     "font-src 'self' data:",
-    `frame-src ${stripeJs}`,
+    `frame-src 'self' ${stripeJs} ${stripeFrames}`,
     "object-src 'none'",
     "base-uri 'self'",
     "form-action 'self'",
@@ -79,9 +85,6 @@ export async function middleware(request: NextRequest) {
     "Strict-Transport-Security",
     "max-age=15552000; includeSubDomains; preload"
   );
-
-  // Pass nonce to the response for use in layout
-  response.headers.set("X-Nonce", nonce);
 
   return response;
 }


### PR DESCRIPTION
## Summary
- Add per-request CSP nonce and remove unsafe-inline from script-src in production.
- Expand CSP for Stripe/Vercel/Supabase connections.

## Notes
- style-src-attr remains unsafe-inline due to existing inline styles; script-src is nonce-based.

Closes #307