### PR TITLE
Force dynamic rendering for CSP nonce in production

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,7 +9,7 @@ import { LanguageProvider } from "@/contexts/LanguageContext";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import CosmicBackground from "@/components/ui/CosmicBackground";
 import Image from "next/image";
-import dynamic from "next/dynamic";
+import dynamicImport from "next/dynamic";
 import { ToastProvider } from "@/components/feedback/ToastProvider";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { Analytics } from "@vercel/analytics/react";
@@ -50,7 +50,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   if (typeof window !== "undefined") {
     warnIfStripeEnvInvalid();
   }
-  const ServiceWorkerRegister = dynamic(
+  const ServiceWorkerRegister = dynamicImport(
     () => import("@/components/performance/ServiceWorkerRegister"),
     { ssr: false }
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -42,6 +42,9 @@ export const metadata = {
   description: "Premium bottled cocktails in the Netherlands",
 };
 
+// Force dynamic rendering so Next can inject CSP nonces into inline scripts.
+export const dynamic = "force-dynamic";
+
 export default function RootLayout({ children }: { children: ReactNode }) {
   // Dev-only diagnostics
   if (typeof window !== "undefined") {


### PR DESCRIPTION
## Summary
- Force App Router to render dynamically so CSP nonce can be injected into inline scripts.
- Resolve name conflict in layout caused by `dynamic` export + `next/dynamic` import.
- Remove inline `<style>` blocks blocked by CSP and move them to global CSS.
- Add a minimal `/quiz` page to eliminate 404 when clicking the quiz CTA.
- Expose the nonce via `<noscript data-n-css>` so Next can attach it to client-side injected styles on navigation.

## Why
Production pages were blank because HTML was statically cached and inline scripts were missing a nonce, so CSP blocked them. CSP console errors on navigation were caused by client-side injected styles missing a nonce and a missing `/quiz` route.

Closes #331
