### PR TITLE
Fix remaining CSP console errors and add quiz page

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import "@/styles/globals.css";
 import { ReactNode } from "react";
+import { headers } from "next/headers";
 
 import Navbar from "@/components/layout/Navbar";
 import Footer from "@/components/layout/Footer";
@@ -46,6 +47,7 @@ export const metadata = {
 export const dynamic = "force-dynamic";
 
 export default function RootLayout({ children }: { children: ReactNode }) {
+  const nonce = headers().get("x-nonce") ?? undefined;
   // Dev-only diagnostics
   if (typeof window !== "undefined") {
     warnIfStripeEnvInvalid();
@@ -56,6 +58,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   );
   return (
     <html lang="en">
+      <head>{nonce ? <noscript data-n-css={nonce} /> : null}</head>
       <body className={`${unica.variable} ${josefin.variable} font-sans`}>
         <ErrorBoundary>
           <LanguageProvider>

--- a/src/app/quiz/page.tsx
+++ b/src/app/quiz/page.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+
+export const metadata = {
+  title: "CosmoCocktails Quiz",
+  description: "Encuentra tu cóctel ideal con nuestro quiz.",
+};
+
+export default function QuizPage() {
+  return (
+    <section className="mx-auto flex min-h-[60vh] max-w-4xl flex-col items-center justify-center gap-6 px-6 py-16 text-center text-white">
+      <div className="space-y-3">
+        <h1 className="text-3xl font-semibold sm:text-4xl">Cocktail Quiz</h1>
+        <p className="text-base text-cosmic-silver">
+          Estamos preparando el quiz para recomendarte el cóctel perfecto.
+        </p>
+      </div>
+      <div className="flex flex-wrap items-center justify-center gap-3">
+        <Link
+          href="/shop"
+          className="rounded-full bg-cosmic-gold px-5 py-2 text-sm font-semibold text-black transition hover:bg-cosmic-gold/85"
+        >
+          Ir a la tienda
+        </Link>
+        <Link
+          href="/"
+          className="rounded-full border border-white/20 px-5 py-2 text-sm text-white/80 transition hover:text-white hover:border-white/40"
+        >
+          Volver al inicio
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/src/app/shop/components/FeaturedBanner.tsx
+++ b/src/app/shop/components/FeaturedBanner.tsx
@@ -231,22 +231,6 @@ export default function FeaturedBanner() {
         </div>
       )}
 
-      <style jsx global>{`
-        .featured-swiper .swiper-pagination-bullet {
-          width: 10px;
-          height: 10px;
-          opacity: 1;
-          background: rgba(209, 184, 127, 0.35);
-          border: 1px solid rgba(209, 184, 127, 0.6);
-          transition: transform 0.2s ease, background 0.2s ease;
-        }
-
-        .featured-swiper .swiper-pagination-bullet-active {
-          background: rgba(209, 184, 127, 0.95);
-          transform: scale(1.1);
-          box-shadow: 0 0 8px rgba(209, 184, 127, 0.6);
-        }
-      `}</style>
     </>
   );
 }

--- a/src/components/order/OrderReceipt.tsx
+++ b/src/components/order/OrderReceipt.tsx
@@ -21,17 +21,6 @@ export default function OrderReceipt({ order, items }: Props) {
   const print = () => window.print();
   return (
     <>
-      <style>{`
-      @media print {
-        body { background: white; color: #111; }
-        .receipt { width: 700px; margin: 0 auto; font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
-        .receipt h1 { font-size: 18px; margin: 0 0 8px; }
-        .receipt .muted { color: #666; }
-        .receipt .row { display:flex; justify-content:space-between; padding:6px 0; border-bottom:1px solid #eee; }
-        .receipt .row:last-child { border-bottom: none; }
-        .no-print { display: none !important; }
-      }
-      `}</style>
       <button
         onClick={print}
         className="text-cosmic-silver hover:text-cosmic-gold underline-offset-4 hover:underline text-sm"

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,6 +2,59 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Featured banner pagination styles (moved from inline styles for CSP) */
+.featured-swiper .swiper-pagination-bullet {
+  width: 10px;
+  height: 10px;
+  opacity: 1;
+  background: rgba(209, 184, 127, 0.35);
+  border: 1px solid rgba(209, 184, 127, 0.6);
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.featured-swiper .swiper-pagination-bullet-active {
+  background: rgba(209, 184, 127, 0.95);
+  transform: scale(1.1);
+  box-shadow: 0 0 8px rgba(209, 184, 127, 0.6);
+}
+
+/* Printable order receipt styles (moved from inline styles for CSP) */
+@media print {
+  body {
+    background: white;
+    color: #111;
+  }
+
+  .receipt {
+    width: 700px;
+    margin: 0 auto;
+    font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  }
+
+  .receipt h1 {
+    font-size: 18px;
+    margin: 0 0 8px;
+  }
+
+  .receipt .muted {
+    color: #666;
+  }
+
+  .receipt .row {
+    display: flex;
+    justify-content: space-between;
+    padding: 6px 0;
+    border-bottom: 1px solid #eee;
+  }
+
+  .receipt .row:last-child {
+    border-bottom: none;
+  }
+
+  .no-print {
+    display: none !important;
+  }
+}
 body {
   @apply bg-cosmic-bg text-cosmic-text font-sans;
 }


### PR DESCRIPTION
## Summary
- Remove inline `<style>` blocks blocked by CSP and move them to global CSS.
- Add a minimal `/quiz` page for the home CTA.
- Provide `<noscript data-n-css>` so Next can apply nonce to client-injected styles.

## Why
Remaining CSP console errors were caused by client-injected styles missing a nonce. The quiz CTA pointed to a missing route.

Closes #335
