### PR TITLE
M1.02 Shop search: include descriptions

### DIFF
--- a/src/app/shop/ShopClient.tsx
+++ b/src/app/shop/ShopClient.tsx
@@ -123,7 +123,12 @@ export default function ShopClient({
       );
 
       if (trimmedQuery) {
-        queryBuilder = queryBuilder.ilike("name", `%${trimmedQuery}%`);
+        const safeQuery = trimmedQuery
+          .replace(/[%_]/g, "\\$&")
+          .replace(/,/g, " ");
+        queryBuilder = queryBuilder.or(
+          `name.ilike.%${safeQuery}%,description.ilike.%${safeQuery}%`
+        );
       }
 
       const { data: cocktailRows, error, count } = await queryBuilder


### PR DESCRIPTION
## Summary
- Expand product search to match both name and description.
- Sanitize wildcard characters for safer ilike queries.

## Why
The search bar was already present, but it only searched by name. This makes it more useful and aligned with M1.02.

Closes #40
